### PR TITLE
Plot violins in a specified order

### DIFF
--- a/test_cases/testviolinplot.m
+++ b/test_cases/testviolinplot.m
@@ -1,0 +1,21 @@
+
+% TEST CASE 1
+display('Test 1: Violin plot default options');
+load carbig MPG Origin
+Origin = cellstr(Origin);
+figure
+vs = violinplot(MPG, Origin);
+ylabel('Fuel Economy in MPG');
+xlim([0.5, 7.5]);
+
+display('Test 1 passed ok');
+
+% TEST CASE 2
+display('Test 2: Test the plot ordering option');
+grouporder={'USA','Sweden','Japan','Italy','Germany','France','England'};
+    
+figure;
+vs2 = violinplot(MPG,Origin,'GroupOrder',grouporder);
+display('Test 2 passed ok');
+
+%other test cases could be added here

--- a/violinplot.m
+++ b/violinplot.m
@@ -90,7 +90,7 @@ function violins = violinplot(data, cats, varargin)
         if isempty(grouporder)
             cats = categorical(cats);
         else
-            cats = categorical(cats,grouporder);
+            cats = categorical(cats, grouporder);
         end
 
         catnames = categories(cats);

--- a/violinplot.m
+++ b/violinplot.m
@@ -49,7 +49,6 @@ function violins = violinplot(data, cats, varargin)
 
 % Copyright (c) 2016, Bastian Bechtold
 % This code is released under the terms of the BSD 3-clause license
-%modified 190606 to allow category ordering
 
     hascategories = exist('cats','var') && not(isempty(cats));
     grouporder = {};

--- a/violinplot.m
+++ b/violinplot.m
@@ -44,11 +44,26 @@ function violins = violinplot(data, cats, varargin)
 %                    Defaults to false
 %     'ShowMean'     Whether to show mean indicator
 %                    Defaults to false
+%     'GroupOrder'   Cell of category names in order to be plotted.
+%                    Defaults to alphabetical ordering
 
 % Copyright (c) 2016, Bastian Bechtold
 % This code is released under the terms of the BSD 3-clause license
+%modified 190606 to allow category ordering
 
     hascategories = exist('cats','var') && not(isempty(cats));
+    grouporder = {};
+    ii=1;
+    while ii<=numel(varargin)
+        if strcmp(varargin{ii},'GroupOrder')
+            grouporder = varargin{ii+1};
+            varargin(ii:ii+1)=[];
+            ii=ii+2;
+        else
+            ii=ii+1;
+        end
+    end
+
 
     % tabular data
     if isa(data, 'dataset') || isstruct(data) || istable(data)
@@ -73,7 +88,12 @@ function violins = violinplot(data, cats, varargin)
 
     % 1D data, one category for each data point
     elseif hascategories && numel(data) == numel(cats)
-        cats = categorical(cats);
+        if isempty(grouporder)
+            cats = categorical(cats);
+        else
+            cats = categorical(cats,grouporder);
+        end
+
         catnames = categories(cats);
         for n=1:length(catnames)
             thisCat = catnames{n};

--- a/violinplot.m
+++ b/violinplot.m
@@ -51,18 +51,20 @@ function violins = violinplot(data, cats, varargin)
 % This code is released under the terms of the BSD 3-clause license
 
     hascategories = exist('cats','var') && not(isempty(cats));
+    
+    %parse the optional grouporder argument 
+    %if it exists parse the categories order 
+    % but also delete it from the arguments passed to Violin
     grouporder = {};
-    ii=1;
-    while ii<=numel(varargin)
-        if strcmp(varargin{ii},'GroupOrder')
-            grouporder = varargin{ii+1};
-            varargin(ii:ii+1)=[];
-            ii=ii+2;
+    idx=find(strcmp(varargin, 'GroupOrder'));
+    if ~isempty(idx) && numel(varargin)>idx
+        if iscell(varargin{idx+1})
+            grouporder = varargin{idx+1};
+            varargin(idx:idx+1)=[];
         else
-            ii=ii+1;
+            error('Second argument of ''GroupOrder'' optional arg must be a cell of category names')
         end
     end
-
 
     % tabular data
     if isa(data, 'dataset') || isstruct(data) || istable(data)


### PR DESCRIPTION
Added optional argument 'GroupOrder', {OrderCell} which allows the order of side by side violins to be specified.
It's a bit hacky as this is done in violinplot.m rather than the Violin class but this seemed the simplest way to do it.
Currently only tested using the data input format (Data,Label) as this is what I use. Looking at how categories work it should work fine anyway though.