### PR TITLE
fixed a bug where fragmented categorical data crashed the plot function

### DIFF
--- a/Violin.m
+++ b/Violin.m
@@ -115,6 +115,9 @@ classdef Violin < handle
             hold('on');
 
             % calculate kernel density estimation for the violin
+            if isempty(data)
+                return
+            end
             [density, value] = ksdensity(data, 'bandwidth', args.Bandwidth);
             density = density(value >= min(data) & value <= max(data));
             value = value(value >= min(data) & value <= max(data));

--- a/violinplot.m
+++ b/violinplot.m
@@ -104,7 +104,7 @@ function violins = violinplot(data, cats, varargin)
             thisData = data(cats == thisCat);
             violins(n) = Violin(thisData, n, varargin{:});
         end
-        set(gca, 'XTick', 1:length(catnames), 'XTickLabels', catnames_labels,'XTickLabelRotation',45);
+        set(gca, 'XTick', 1:length(catnames), 'XTickLabels', catnames_labels);
 
     % 1D data, no categories
     elseif not(hascategories) && isvector(data)

--- a/violinplot.m
+++ b/violinplot.m
@@ -85,28 +85,31 @@ function violins = violinplot(data, cats, varargin)
             thisData = data.(catnames{n});
             violins(n) = Violin(thisData, n, varargin{:});
         end
-        set(gca, 'xtick', 1:length(catnames), 'xticklabels', catnames);
+        set(gca, 'XTick', 1:length(catnames), 'XTickLabels', catnames);
 
     % 1D data, one category for each data point
     elseif hascategories && numel(data) == numel(cats)
+
         if isempty(grouporder)
             cats = categorical(cats);
         else
             cats = categorical(cats, grouporder);
         end
 
-        catnames = categories(cats);
-        for n=1:length(catnames)
-            thisCat = catnames{n};
+        catnames = (unique(cats)); % this ignores categories without any data
+        catnames_labels = {};
+        for n = 1:length(catnames)
+            thisCat = catnames(n);
+            catnames_labels{n} = char(thisCat);
             thisData = data(cats == thisCat);
             violins(n) = Violin(thisData, n, varargin{:});
         end
-        set(gca, 'xtick', 1:length(catnames), 'xticklabels', catnames);
+        set(gca, 'XTick', 1:length(catnames), 'XTickLabels', catnames_labels,'XTickLabelRotation',45);
 
     % 1D data, no categories
     elseif not(hascategories) && isvector(data)
         violins = Violin(data, 1, varargin{:});
-        set(gca, 'xtick', 1);
+        set(gca, 'XTick', 1);
 
     % 2D data with or without categories
     elseif ismatrix(data)
@@ -114,9 +117,9 @@ function violins = violinplot(data, cats, varargin)
             thisData = data(:, n);
             violins(n) = Violin(thisData, n, varargin{:});
         end
-        set(gca, 'xtick', 1:size(data, 2));
+        set(gca, 'XTick', 1:size(data, 2));
         if hascategories && length(cats) == size(data, 2)
-            set(gca, 'xticklabels', cats);
+            set(gca, 'XTickLabels', cats);
         end
 
     end


### PR DESCRIPTION
This patch fixes a bug where a categorical array with some categories not being represented crashed the plot function. This was because the plot function looped over the categories, instead of the unique values in the categorical array. 