### PR TITLE
Load more than 7 colours if needed

### DIFF
--- a/Violin.m
+++ b/Violin.m
@@ -166,6 +166,9 @@ classdef Violin < handle
             
             if isempty(args.ViolinColor)
                 C = colororder;
+                if pos > length(C)
+                    C = lines;
+                end
                 args.ViolinColor = {repmat(C,ceil(size(data,2)/length(C)),1)};
             end
             


### PR DESCRIPTION
Thanks @LucyIris for spotting this error!

This commit fixes #41 
Now if more than 7 violin plots are needed it would load the lines colourmap.

