### PR TITLE
fix scatter display (alpha/MarkerSize)

### DIFF
--- a/Violin.m
+++ b/Violin.m
@@ -86,21 +86,22 @@ classdef Violin < handle
     end
     
     properties (Dependent=true)
-        ViolinColor     % fill color of the violin area and data points
-        ViolinAlpha     % transparency of the violin area and data points
-        MarkerSize      % marker size for the median dot
-        LineWidth       % linewidth of the median plot
-        EdgeColor       % color of the violin area outline
-        BoxColor        % color of box, whiskers, and median/notch edges
-        BoxWidth        % width of box between the quartiles in axis space (default 10% of Violin plot width, 0.03)
-        MedianColor     % fill color of median and notches
-        ShowData        % whether to show data points
-        ShowNotches     % whether to show notch indicators
-        ShowMean        % whether to show mean indicator
-        ShowBox         % whether to show the box
-        ShowMedian      % whether to show the median line
-        ShowWhiskers    % whether to show the whiskers
-        HalfViolin      % whether to do a half violin(left, right side) or full
+        ViolinColor         % fill color of the violin area and data points
+        ViolinAlpha         % transparency of the violin area and data points
+        MarkerSize          % marker size for the data dots
+        MedianMarkerSize    % marker size for the median dot
+        LineWidth           % linewidth of the median plot
+        EdgeColor           % color of the violin area outline
+        BoxColor            % color of box, whiskers, and median/notch edges
+        BoxWidth            % width of box between the quartiles in axis space (default 10% of Violin plot width, 0.03)
+        MedianColor         % fill color of median and notches
+        ShowData            % whether to show data points
+        ShowNotches         % whether to show notch indicators
+        ShowMean            % whether to show mean indicator
+        ShowBox             % whether to show the box
+        ShowMedian          % whether to show the median line
+        ShowWhiskers        % whether to show the whiskers
+        HalfViolin          % whether to do a half violin(left, right side) or full
     end
     
     methods
@@ -124,6 +125,10 @@ classdef Violin < handle
             %                    points. Can be either a single scalar
             %                    value or an array of up to two cells
             %                    containing scalar values. Defaults to 0.3.
+            %     'MarkerSize'   Size of the data points, if shown.
+            %                    Defaults to 24
+            % 'MedianMarkerSize' Size of the median indicator, if shown.
+            %                    Defaults to 36
             %     'EdgeColor'    Color of the violin area outline.
             %                    Defaults to [0.5 0.5 0.5]
             %     'BoxColor'     Color of the box, whiskers, and the
@@ -347,7 +352,7 @@ classdef Violin < handle
             end
                 
             % Median
-            obj.MedianPlot = scatter(pos, quartiles(2), args.MarkerSize, [1 1 1], 'filled');
+            obj.MedianPlot = scatter(pos, quartiles(2), args.MedianMarkerSize, [1 1 1], 'filled');
                 
             % Notches
             obj.NotchPlots = ...
@@ -652,7 +657,8 @@ classdef Violin < handle
             p.addParameter('Bandwidth', [], isscalarnumber);
             iscolor = @(x) (isnumeric(x) & size(x,2) == 3);
             p.addParameter('ViolinColor', [], @(x)iscolor(vertcat(x{:})));
-            p.addParameter('MarkerSize', 36, @isnumeric);
+            p.addParameter('MarkerSize', 24, @isnumeric);
+            p.addParameter('MedianMarkerSize', 36, @isnumeric);
             p.addParameter('LineWidth', 0.75, @isnumeric);
             p.addParameter('BoxColor', [0.5 0.5 0.5], iscolor);
             p.addParameter('BoxWidth', 0.01, isscalarnumber);

--- a/Violin.m
+++ b/Violin.m
@@ -225,7 +225,7 @@ classdef Violin < handle
                     if ~isempty(data2)
                         jitter = 1*(rand(size(data))); %right
                         obj.ScatterPlot = ...
-                            scatter(pos + jitter.*jitterstrength, data, 'filled');
+                            scatter(pos + jitter.*jitterstrength, data, args.MarkerSize, 'filled');
                         % plot the data points within the violin area
                         if length(densityC) > 1
                             jitterstrength = interp1(valueC, densityC*widthC, data2);
@@ -234,7 +234,7 @@ classdef Violin < handle
                         end
                         jitter = -1*rand(size(data2));% left
                         obj.ScatterPlot2 = ...
-                            scatter(pos + jitter.*jitterstrength, data2,  args.MarkerSize,'filled');         
+                            scatter(pos + jitter.*jitterstrength, data2, args.MarkerSize, 'filled');         
                     else 
                         obj.ScatterPlot = ...
                             scatter(pos + jitter.*jitterstrength, data, args.MarkerSize, 'filled');
@@ -517,7 +517,7 @@ classdef Violin < handle
             obj.ScatterPlot.MarkerFaceAlpha = 1;
             if ~isempty(obj.ViolinPlot2)
                 obj.ViolinPlot2.FaceAlpha = alpha{2};
-                obj.ScatterPlot2.MarkerFaceAlpha = alpha{2};
+                obj.ScatterPlot2.MarkerFaceAlpha = 1;
             end
         end
                 

--- a/test_cases/testviolinplot.m
+++ b/test_cases/testviolinplot.m
@@ -38,7 +38,7 @@ plotdetails(3);
 disp('Test 4: Test two sided violin plots. Japan is being compared.');
 subplot(2,4,4); 
 C = colororder;
-vs4 = violinplot({thisData,repmat(thisData(:,5),1,7)},catnames_labels,'ViolinColor',{C,C(5,:)},'ViolinAlpha',{0.3 0.3}, 'ShowMean', true);
+vs4 = violinplot({thisData,repmat(thisData(:,5),1,7)},catnames_labels,'ViolinColor',{C,C(5,:)},'ViolinAlpha',{0.3 0.3}, 'ShowMean', true, 'MarkerSize',8);
 plotdetails(4);
 
 % TEST CASE 5

--- a/violinplot.m
+++ b/violinplot.m
@@ -44,6 +44,10 @@ function violins = violinplot(data, cats, varargin)
 %                    Can be either a single scalar value or an array of
 %                    up to two cells containing scalar values.
 %                    Defaults to 0.3.
+%     'MarkerSize'   Size of the data points, if shown.
+%                    Defaults to 24
+% 'MedianMarkerSize' Size of the median indicator, if shown.
+%                    Defaults to 36
 %     'EdgeColor'    Color of the violin area outline.
 %                    Defaults to [0.5 0.5 0.5]
 %     'BoxColor'     Color of the box, whiskers, and the outlines of


### PR DESCRIPTION
Hi Bastian,

I hope it's ok to create a pull request directly without opening any issues. But I only fixed two minor bugs when plotting the two-sided violins.

First, the alpha was set =1 only for the first (right) violin. And secondly, specifying MarkerSize also affected the first (right) violin only. 

And the third change in line 237 is just to keep coding-style consistent.

Best,
Adam