### PR TITLE
change strings to char array for old matlab compatibility

### DIFF
--- a/Violin.m
+++ b/Violin.m
@@ -423,8 +423,8 @@ classdef Violin < handle
             end
             obj.ViolinAlpha = ViolinAlpha;
                 
-            set(obj.ViolinPlot, "Marker", "none", "LineStyle","-");
-            set(obj.ViolinPlot2, "Marker", "none", "LineStyle","-");
+            set(obj.ViolinPlot, 'Marker', 'none', 'LineStyle', '-');
+            set(obj.ViolinPlot2, 'Marker', 'none', 'LineStyle', '-');
         end
             
         %% SET METHODS


### PR DESCRIPTION
My MATLAB R2017b supports strings, but it seems the set function doesn't handle them well.
To work around this, I used char arrays for parameters.
I assume this workaround is compatible with newer versions as well, considering that char arrays are used elsewhere in the code.

Best,
Alessandro.